### PR TITLE
Allow syapse to report back coarse grained CPU and Memory usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-from golang
+FROM golang
 
 RUN apt-get update && apt-get install sqlite3 && apt-get clean
 WORKDIR /go/src/panopticon

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+from golang
+
+RUN apt-get update && apt-get install sqlite3 && apt-get clean
+WORKDIR /go/src/panopticon
+RUN go get github.com/mattn/go-sqlite3
+RUN go get github.com/go-sql-driver/mysql
+
+COPY ./runtests.sh /go/src/panopticon
+COPY ./tests /go/src/panopticon/tests
+COPY ./main.go /go/src/panopticon
+RUN go build
+CMD ./runtests.sh
+

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ To build, run:
 go build
 ```
 
+
 ## Testing
-To run tests, run `./runtests.sh`
+There is a docker file that builds panopticon and runs the tests as above.
+
+This only requires docker on your local workstation, no go install or dependencies required.
+
+```sh
+docker-tests.sh
 To add new tests, crib exiting files in the `tests` directory.

--- a/docker-tests.sh
+++ b/docker-tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 docker build . -t panopticon
-docker run -t panopticon
+docker run -t --rm panopticon

--- a/docker-tests.sh
+++ b/docker-tests.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker build . -t panopticon
+docker run -t panopticon

--- a/main.go
+++ b/main.go
@@ -122,7 +122,7 @@ func (r *Recorder) Save(sr StatsReport) error {
 
 	cols, vals = appendIfNonNil(cols, vals, "cpu_average", sr.CPUAverage)
 	cols, vals = appendIfNonNil(cols, vals, "memory_rss", sr.MemoryRSS)
-	cols, vals = appendIfNonNil(cols, vals, "cache_factor", sr.CacheFactor)
+	cols, vals = appendIfNonNilFloat(cols, vals, "cache_factor", sr.CacheFactor)
 	cols, vals = appendIfNonNil(cols, vals, "event_cache_size", sr.EventCacheSize)
 
 	var valuePlaceholders []string
@@ -141,6 +141,13 @@ func (r *Recorder) Save(sr StatsReport) error {
 	return err
 }
 
+func appendIfNonNilFloat(cols []string, vals []interface{}, name string, value *float64) ([]string, []interface{}) {
+	if value != nil {
+		cols = append(cols, name)
+		vals = append(vals, value)
+	}
+	return cols, vals
+}
 func appendIfNonNil(cols []string, vals []interface{}, name string, value *int64) ([]string, []interface{}) {
 	if value != nil {
 		cols = append(cols, name)

--- a/main.go
+++ b/main.go
@@ -52,6 +52,8 @@ type StatsReport struct {
 	DailyMessages        *int64 `json:"daily_messages"`
 	DailySentMessages    *int64 `json:"daily_sent_messages"`
 	DailyActiveRooms     *int64 `json:"daily_active_rooms"`
+	MemoryRSS            *int64 `json:"memory_rss"`
+	CPUAverage           *int64 `json:"cpu_average"`
 	RemoteAddr           string
 	XForwardedFor        string
 	UserAgent            string
@@ -115,6 +117,9 @@ func (r *Recorder) Save(sr StatsReport) error {
 	cols, vals = appendIfNonNil(cols, vals, "daily_sent_messages", sr.DailySentMessages)
 	cols, vals = appendIfNonEmpty(cols, vals, "forwarded_for", sr.XForwardedFor)
 	cols, vals = appendIfNonEmpty(cols, vals, "user_agent", sr.UserAgent)
+
+	cols, vals = appendIfNonNil(cols, vals, "cpu_average", sr.CPUAverage)
+	cols, vals = appendIfNonNil(cols, vals, "memory_rss", sr.MemoryRSS)
 
 	var valuePlaceholders []string
 	for i := range vals {
@@ -180,6 +185,8 @@ func createTable(db *sql.DB) error {
 		daily_active_rooms BIGINT,
 		daily_messages BIGINT,
 		daily_sent_messages BIGINT,
+		cpu_average BIGINT,
+		memory_rss BIGINT,
 		user_agent TEXT
 		)`)
 	return err

--- a/main.go
+++ b/main.go
@@ -55,6 +55,7 @@ type StatsReport struct {
 	MemoryRSS            *int64 `json:"memory_rss"`
 	CPUAverage           *int64 `json:"cpu_average"`
 	CacheFactor          *int64 `json:"cache_factor"`
+	EventCacheSize       *int64 `json:"event_cache_size"`
 	RemoteAddr           string
 	XForwardedFor        string
 	UserAgent            string
@@ -122,6 +123,7 @@ func (r *Recorder) Save(sr StatsReport) error {
 	cols, vals = appendIfNonNil(cols, vals, "cpu_average", sr.CPUAverage)
 	cols, vals = appendIfNonNil(cols, vals, "memory_rss", sr.MemoryRSS)
 	cols, vals = appendIfNonNil(cols, vals, "cache_factor", sr.CacheFactor)
+	cols, vals = appendIfNonNil(cols, vals, "event_cache_size", sr.EventCacheSize)
 
 	var valuePlaceholders []string
 	for i := range vals {
@@ -190,6 +192,7 @@ func createTable(db *sql.DB) error {
 		cpu_average BIGINT,
 		memory_rss BIGINT,
 		cache_factor BIGINT,
+		event_cache_size BIGINT,
 		user_agent TEXT
 		)`)
 	return err

--- a/main.go
+++ b/main.go
@@ -54,6 +54,7 @@ type StatsReport struct {
 	DailyActiveRooms     *int64 `json:"daily_active_rooms"`
 	MemoryRSS            *int64 `json:"memory_rss"`
 	CPUAverage           *int64 `json:"cpu_average"`
+	CacheFactor          *int64 `json:"cache_factor"`
 	RemoteAddr           string
 	XForwardedFor        string
 	UserAgent            string
@@ -120,6 +121,7 @@ func (r *Recorder) Save(sr StatsReport) error {
 
 	cols, vals = appendIfNonNil(cols, vals, "cpu_average", sr.CPUAverage)
 	cols, vals = appendIfNonNil(cols, vals, "memory_rss", sr.MemoryRSS)
+	cols, vals = appendIfNonNil(cols, vals, "cache_factor", sr.CacheFactor)
 
 	var valuePlaceholders []string
 	for i := range vals {
@@ -187,6 +189,7 @@ func createTable(db *sql.DB) error {
 		daily_sent_messages BIGINT,
 		cpu_average BIGINT,
 		memory_rss BIGINT,
+		cache_factor BIGINT,
 		user_agent TEXT
 		)`)
 	return err

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ type StatsReport struct {
 	DailyActiveRooms     *int64 `json:"daily_active_rooms"`
 	MemoryRSS            *int64 `json:"memory_rss"`
 	CPUAverage           *int64 `json:"cpu_average"`
-	CacheFactor          *int64 `json:"cache_factor"`
+	CacheFactor          *float64 `json:"cache_factor"`
 	EventCacheSize       *int64 `json:"event_cache_size"`
 	RemoteAddr           string
 	XForwardedFor        string
@@ -191,7 +191,7 @@ func createTable(db *sql.DB) error {
 		daily_sent_messages BIGINT,
 		cpu_average BIGINT,
 		memory_rss BIGINT,
-		cache_factor BIGINT,
+		cache_factor DOUBLE,
 		event_cache_size BIGINT,
 		user_agent TEXT
 		)`)

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -24,8 +24,9 @@ port=9002
 
 cd $(dirname $(dirname $(realpath $0)))
 ./panopticon --port=${port} --db=${dir}/stats.db 2>$1 &
+PID=$! 
 function kill_server {
-  kill $(lsof -i | grep ":${port} " | awk '{print $2}')
+  kill $PID
 }
 
 trap kill_server EXIT

--- a/tests/test_push_good.sh
+++ b/tests/test_push_good.sh
@@ -2,8 +2,8 @@
 
 . $(dirname $0)/setup.sh
 log "Testing /push with beyond 0.27.2 pushes"
-assert_eq "{}" "$(curl -k -d '{"daily_active_users": 10, "timestamp": 20, "total_users": 123, "total_room_count": 17, "daily_messages": 9, "uptime_seconds": 19, "homeserver": "many.turtles", "memory_rss": 12, "cpu_average": 125}' http://localhost:${port}/push 2>/dev/null)"
-assert_eq "10|123|17|9|20|19|125|12" "$(sqlite3 ${dir}/stats.db 'SELECT daily_active_users, total_users, total_room_count, daily_messages, remote_timestamp, uptime_seconds, cpu_average, memory_rss FROM stats WHERE homeserver == "many.turtles"')"
+assert_eq "{}" "$(curl -k -d '{"daily_active_users": 10, "timestamp": 20, "total_users": 123, "total_room_count": 17, "daily_messages": 9, "uptime_seconds": 19, "homeserver": "many.turtles", "memory_rss": 12, "cpu_average": 125, "cache_factor": 5}' http://localhost:${port}/push 2>/dev/null)"
+assert_eq "10|123|17|9|20|19|125|12|5" "$(sqlite3 ${dir}/stats.db 'SELECT daily_active_users, total_users, total_room_count, daily_messages, remote_timestamp, uptime_seconds, cpu_average, memory_rss, cache_factor FROM stats WHERE homeserver == "many.turtles"')"
 assert_eq "1" "$(sqlite3 ${dir}/stats.db 'SELECT COUNT(*) AS count FROM stats WHERE homeserver == "many.turtles" AND (remote_addr LIKE "127.0.0.1%" OR remote_addr LIKE "[::1]%")')"
 
 sleep 2

--- a/tests/test_push_good.sh
+++ b/tests/test_push_good.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
 . $(dirname $0)/setup.sh
-log "Testing /push with 0.23.x - pushes"
+log "Testing /push with beyond 0.27.2 pushes"
 assert_eq "{}" "$(curl -k -d '{"daily_active_users": 10, "timestamp": 20, "total_users": 123, "total_room_count": 17, "daily_messages": 9, "uptime_seconds": 19, "homeserver": "many.turtles", "memory_rss": 12, "cpu_average": 125}' http://localhost:${port}/push 2>/dev/null)"
 assert_eq "10|123|17|9|20|19|125|12" "$(sqlite3 ${dir}/stats.db 'SELECT daily_active_users, total_users, total_room_count, daily_messages, remote_timestamp, uptime_seconds, cpu_average, memory_rss FROM stats WHERE homeserver == "many.turtles"')"
 assert_eq "1" "$(sqlite3 ${dir}/stats.db 'SELECT COUNT(*) AS count FROM stats WHERE homeserver == "many.turtles" AND (remote_addr LIKE "127.0.0.1%" OR remote_addr LIKE "[::1]%")')"
@@ -27,3 +27,4 @@ assert_eq "lower.faraway.turtles" "$(sqlite3 ${dir}/stats.db 'SELECT forwarded_f
 
 assert_eq "{}" "$(curl -k -H "User-Agent: turtle/agent/0.0.7" -d '{"homeserver": "agent.turtles"}' http://localhost:${port}/push 2>/dev/null)"
 assert_eq "turtle/agent/0.0.7" "$(sqlite3 ${dir}/stats.db 'SELECT user_agent FROM stats WHERE homeserver == "agent.turtles"')"
+

--- a/tests/test_push_good.sh
+++ b/tests/test_push_good.sh
@@ -2,8 +2,8 @@
 
 . $(dirname $0)/setup.sh
 log "Testing /push with beyond 0.27.2 pushes"
-assert_eq "{}" "$(curl -k -d '{"daily_active_users": 10, "timestamp": 20, "total_users": 123, "total_room_count": 17, "daily_messages": 9, "uptime_seconds": 19, "homeserver": "many.turtles", "memory_rss": 12, "cpu_average": 125, "cache_factor": 5, "event_cache_size": 10000}' http://localhost:${port}/push 2>/dev/null)"
-assert_eq "10|123|17|9|20|19|125|12|5|10000" "$(sqlite3 ${dir}/stats.db 'SELECT daily_active_users, total_users, total_room_count, daily_messages, remote_timestamp, uptime_seconds, cpu_average, memory_rss, cache_factor, event_cache_size FROM stats WHERE homeserver == "many.turtles"')"
+assert_eq "{}" "$(curl -k -d '{"daily_active_users": 10, "timestamp": 20, "total_users": 123, "total_room_count": 17, "daily_messages": 9, "uptime_seconds": 19, "homeserver": "many.turtles", "memory_rss": 12, "cpu_average": 125, "cache_factor": 5.501, "event_cache_size": 10000}' http://localhost:${port}/push 2>/dev/null)"
+assert_eq "10|123|17|9|20|19|125|12|5.501|10000" "$(sqlite3 ${dir}/stats.db 'SELECT daily_active_users, total_users, total_room_count, daily_messages, remote_timestamp, uptime_seconds, cpu_average, memory_rss, cache_factor, event_cache_size FROM stats WHERE homeserver == "many.turtles"')"
 assert_eq "1" "$(sqlite3 ${dir}/stats.db 'SELECT COUNT(*) AS count FROM stats WHERE homeserver == "many.turtles" AND (remote_addr LIKE "127.0.0.1%" OR remote_addr LIKE "[::1]%")')"
 
 sleep 2

--- a/tests/test_push_good.sh
+++ b/tests/test_push_good.sh
@@ -2,8 +2,8 @@
 
 . $(dirname $0)/setup.sh
 log "Testing /push with beyond 0.27.2 pushes"
-assert_eq "{}" "$(curl -k -d '{"daily_active_users": 10, "timestamp": 20, "total_users": 123, "total_room_count": 17, "daily_messages": 9, "uptime_seconds": 19, "homeserver": "many.turtles", "memory_rss": 12, "cpu_average": 125, "cache_factor": 5}' http://localhost:${port}/push 2>/dev/null)"
-assert_eq "10|123|17|9|20|19|125|12|5" "$(sqlite3 ${dir}/stats.db 'SELECT daily_active_users, total_users, total_room_count, daily_messages, remote_timestamp, uptime_seconds, cpu_average, memory_rss, cache_factor FROM stats WHERE homeserver == "many.turtles"')"
+assert_eq "{}" "$(curl -k -d '{"daily_active_users": 10, "timestamp": 20, "total_users": 123, "total_room_count": 17, "daily_messages": 9, "uptime_seconds": 19, "homeserver": "many.turtles", "memory_rss": 12, "cpu_average": 125, "cache_factor": 5, "event_cache_size": 10000}' http://localhost:${port}/push 2>/dev/null)"
+assert_eq "10|123|17|9|20|19|125|12|5|10000" "$(sqlite3 ${dir}/stats.db 'SELECT daily_active_users, total_users, total_room_count, daily_messages, remote_timestamp, uptime_seconds, cpu_average, memory_rss, cache_factor, event_cache_size FROM stats WHERE homeserver == "many.turtles"')"
 assert_eq "1" "$(sqlite3 ${dir}/stats.db 'SELECT COUNT(*) AS count FROM stats WHERE homeserver == "many.turtles" AND (remote_addr LIKE "127.0.0.1%" OR remote_addr LIKE "[::1]%")')"
 
 sleep 2

--- a/tests/test_push_good_without_cpumem.sh
+++ b/tests/test_push_good_without_cpumem.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
 . $(dirname $0)/setup.sh
-log "Testing /push with 0.15.x - 0.23.x pushes"
+log "Testing /push with 0.15.x - 0.23.2 pushes"
 assert_eq "{}" "$(curl -k -d '{"daily_active_users": 10, "timestamp": 20, "total_users": 123, "total_room_count": 17, "daily_messages": 9, "uptime_seconds": 19, "homeserver": "many.turtles"}' http://localhost:${port}/push 2>/dev/null)"
 assert_eq "10|123|17|9|20|19" "$(sqlite3 ${dir}/stats.db 'SELECT daily_active_users, total_users, total_room_count, daily_messages, remote_timestamp, uptime_seconds FROM stats WHERE homeserver == "many.turtles"')"
 assert_eq "1" "$(sqlite3 ${dir}/stats.db 'SELECT COUNT(*) AS count FROM stats WHERE homeserver == "many.turtles" AND (remote_addr LIKE "127.0.0.1%" OR remote_addr LIKE "[::1]%")')"

--- a/tests/test_push_good_without_cpumem.sh
+++ b/tests/test_push_good_without_cpumem.sh
@@ -1,9 +1,9 @@
 #!/bin/bash -eu
 
 . $(dirname $0)/setup.sh
-log "Testing /push with 0.23.x - pushes"
-assert_eq "{}" "$(curl -k -d '{"daily_active_users": 10, "timestamp": 20, "total_users": 123, "total_room_count": 17, "daily_messages": 9, "uptime_seconds": 19, "homeserver": "many.turtles", "memory_rss": 12, "cpu_average": 125}' http://localhost:${port}/push 2>/dev/null)"
-assert_eq "10|123|17|9|20|19|125|12" "$(sqlite3 ${dir}/stats.db 'SELECT daily_active_users, total_users, total_room_count, daily_messages, remote_timestamp, uptime_seconds, cpu_average, memory_rss FROM stats WHERE homeserver == "many.turtles"')"
+log "Testing /push with 0.15.x - 0.23.x pushes"
+assert_eq "{}" "$(curl -k -d '{"daily_active_users": 10, "timestamp": 20, "total_users": 123, "total_room_count": 17, "daily_messages": 9, "uptime_seconds": 19, "homeserver": "many.turtles"}' http://localhost:${port}/push 2>/dev/null)"
+assert_eq "10|123|17|9|20|19" "$(sqlite3 ${dir}/stats.db 'SELECT daily_active_users, total_users, total_room_count, daily_messages, remote_timestamp, uptime_seconds FROM stats WHERE homeserver == "many.turtles"')"
 assert_eq "1" "$(sqlite3 ${dir}/stats.db 'SELECT COUNT(*) AS count FROM stats WHERE homeserver == "many.turtles" AND (remote_addr LIKE "127.0.0.1%" OR remote_addr LIKE "[::1]%")')"
 
 sleep 2

--- a/tests/test_push_good_without_cpumem.sh
+++ b/tests/test_push_good_without_cpumem.sh
@@ -4,26 +4,3 @@
 log "Testing /push with 0.15.x - 0.23.2 pushes"
 assert_eq "{}" "$(curl -k -d '{"daily_active_users": 10, "timestamp": 20, "total_users": 123, "total_room_count": 17, "daily_messages": 9, "uptime_seconds": 19, "homeserver": "many.turtles"}' http://localhost:${port}/push 2>/dev/null)"
 assert_eq "10|123|17|9|20|19" "$(sqlite3 ${dir}/stats.db 'SELECT daily_active_users, total_users, total_room_count, daily_messages, remote_timestamp, uptime_seconds FROM stats WHERE homeserver == "many.turtles"')"
-assert_eq "1" "$(sqlite3 ${dir}/stats.db 'SELECT COUNT(*) AS count FROM stats WHERE homeserver == "many.turtles" AND (remote_addr LIKE "127.0.0.1%" OR remote_addr LIKE "[::1]%")')"
-
-sleep 2
-assert_eq "{}" "$(curl -k -d '{"daily_active_users": 456, "timestamp": 19, "homeserver": "many.turtles"}' http://localhost:${port}/push 2>/dev/null)"
-assert_eq "10
-456" "$(sqlite3 ${dir}/stats.db 'SELECT daily_active_users FROM stats WHERE homeserver == "many.turtles" ORDER BY daily_active_users ASC')"
-
-assert_eq "456
-10" "$(sqlite3 ${dir}/stats.db 'SELECT daily_active_users FROM stats WHERE homeserver == "many.turtles" ORDER BY remote_timestamp ASC')"
-assert_eq "10
-456" "$(sqlite3 ${dir}/stats.db 'SELECT daily_active_users FROM stats WHERE homeserver == "many.turtles" ORDER BY local_timestamp ASC')"
-
-assert_eq "{}" "$(curl -k -d '{"homeserver": "few.turtles"}' http://localhost:${port}/push 2>/dev/null)"
-assert_eq "|||||" "$(sqlite3 ${dir}/stats.db 'SELECT daily_active_users, total_users, total_room_count, daily_messages, remote_timestamp, uptime_seconds FROM stats WHERE homeserver == "few.turtles"')"
-
-assert_eq "{}" "$(curl -k -H "X-Forwarded-For: faraway.turtles" -d '{"homeserver": "proxied.turtles"}' http://localhost:${port}/push 2>/dev/null)"
-assert_eq "faraway.turtles" "$(sqlite3 ${dir}/stats.db 'SELECT forwarded_for FROM stats WHERE homeserver == "proxied.turtles"')"
-
-assert_eq "{}" "$(curl -k -H "x-forwarded-for: lower.faraway.turtles" -d '{"homeserver": "lower.proxied.turtles"}' http://localhost:${port}/push 2>/dev/null)"
-assert_eq "lower.faraway.turtles" "$(sqlite3 ${dir}/stats.db 'SELECT forwarded_for FROM stats WHERE homeserver == "lower.proxied.turtles"')"
-
-assert_eq "{}" "$(curl -k -H "User-Agent: turtle/agent/0.0.7" -d '{"homeserver": "agent.turtles"}' http://localhost:${port}/push 2>/dev/null)"
-assert_eq "turtle/agent/0.0.7" "$(sqlite3 ${dir}/stats.db 'SELECT user_agent FROM stats WHERE homeserver == "agent.turtles"')"


### PR DESCRIPTION
Add two new (optional) parameters in the payload - cpu_average and memory_rss.

This PR also includes a quick'n'dirty dockerised test environment to not require me having to install and maintain a golang install on my desktop.